### PR TITLE
Add tar.gz assembly archive

### DIFF
--- a/assembly.xml
+++ b/assembly.xml
@@ -9,6 +9,7 @@
     <id>distribution</id>
     <formats>
         <format>zip</format>
+        <format>tgz</format>
     </formats>
     <files>
         <file>


### PR DESCRIPTION
Docker ADD instruction can unpack `tar.gz` archives right to a specified directory